### PR TITLE
Add path for libledger_ffi

### DIFF
--- a/lib/src/ledger/ledger_ffi.dart
+++ b/lib/src/ledger/ledger_ffi.dart
@@ -42,7 +42,9 @@ class LedgerFfi {
     possiblePaths
         .add(path.join(path.joinAll(executablePathListParts), 'Resources'));
     possiblePaths.add(path.join(path.joinAll(currentPathListParts), insideSdk));
-
+    possiblePaths
+        .add(path.join(path.joinAll(path.split(Directory.current.path)), 'Resources'));
+      
     var libraryPath = '';
     var found = false;
 


### PR DESCRIPTION
When I cloned `znn_cli_dart`, I couldn't unlock my wallet due to this error:

> Unhandled exception:
> Zenon SDK Exception: Library libledger_ffi could not be found
> #0      LedgerFfi._dlOpenPlatformSpecific (package:znn_ledger_dart/src/ledger/ledger_ffi.dart:75:7)
> #1      new LedgerFfi._ (package:znn_ledger_dart/src/ledger/ledger_ffi.dart:19:39)
> #2      LedgerFfi.instance (package:znn_ledger_dart/src/ledger/ledger_ffi.dart:22:60)
> #3      LedgerTransport.getLedgerDevices.<anonymous closure> (package:znn_ledger_dart/src/transport/ledger_transport.dart:84:27)
> #4      executeAsync (package:znn_ledger_dart/src/utils/ffi_utils.dart:47:11)
> #5      LedgerTransport.getLedgerDevices (package:znn_ledger_dart/src/transport/ledger_transport.dart:83:26)
> #6      LedgerWalletManager.getWalletDefinitions (package:znn_ledger_dart/src/wallet/manager.dart:18:41)
> #7      getWalletDefinitions.<anonymous closure> (package:znn_cli_dart/utils/wallet.dart:11:47)
> #8      MappedListIterable.elementAt (dart:_internal/iterable.dart:415:31)
> #9      ListIterator.moveNext (dart:_internal/iterable.dart:344:26)
> #10     new _GrowableList._ofEfficientLengthIterable (dart:core-patch/growable_array.dart:189:27)
> #11     new _GrowableList.of (dart:core-patch/growable_array.dart:150:28)
> #12     new List.of (dart:core-patch/array_patch.dart:47:28)
> #13     ListIterable.toList (dart:_internal/iterable.dart:214:7)
> #14     getWalletDefinitions (package:znn_cli_dart/utils/wallet.dart:11:71)
> #15     unlockWallet (package:znn_cli_dart/utils/wallet.dart:28:33)
> #16     main (file:///C:/Users/znn/znn_cli_dart/znn-cli.dart:16:11)
> #17     _delayEntrypointInvocation.<anonymous closure> (dart:isolate-patch/isolate_patch.dart:294:33)
> #18     _RawReceivePort._handleMessage (dart:isolate-patch/isolate_patch.dart:189:12)

This PR adds a path to allow `znn_cli_dart` to find the libledger libs in the local `Resources` folder.

Operating system: Windows 10

In order to reproduce the issue, simply `dart run znn-cli.dart` instead of building it.