### PR TITLE
v0.0.6

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   znn_sdk_dart:
     git:
       url: https://github.com/zenon-network/znn_sdk_dart.git
-      ref: v0.0.7
+      ref: v0.0.8
 
 dev_dependencies:
   build_runner: ^2.4.6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: znn_ledger_dart
 description: Ledger Wallet for Zenon Dart SDK
 publish_to: none
-version: 0.0.5
+version: 0.0.6
 
 environment:
   sdk: '>=2.17.0 <3.0.0'


### PR DESCRIPTION
This PR updates the `znn_sdk_dart` dependency to `v0.0.8` and bumps the version to `v0.0.6`.